### PR TITLE
Update .gitignore and documentation for Morpheus software version 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 site/
+.venv
+

--- a/neo6502/docs/reference/api-listing.md
+++ b/neo6502/docs/reference/api-listing.md
@@ -392,6 +392,10 @@ Parameter:0 is non-zero if the file is at the end of the file.
 
 This call should be used on open files and may return an error if the file is closed.
 
+### Function 23 : Get Current Working Directory.
+
+Copies the current working directory into the String at address Parameters:0,1. which is of maximum length Parameters:2
+
 ### Function 32 : List Filtered
 
 Prints a filtered file listing of the current directory to the console. On input:

--- a/neo6502/docs/welcome/starting.md
+++ b/neo6502/docs/welcome/starting.md
@@ -32,7 +32,7 @@ If you are using the SD card it should come with a short ribbon cable which plug
 
 First you need to download the current release of the Morpheus software [here](https://github.com/paulscottrobson/neo6502-firmware) . 
 
-The releases are on the right of the screen, the current release is 0.30.0. Clicking on it should show the releases page which has a link to "neo6502.zip"
+The releases are on the right of the screen, the current release is 1.0.0. Clicking on it should show the releases page which has a link to "neo6502.zip"
 
 Download and extract this file. You will see something like this, this is Linux, but it will be very similar on Windows or Macintosh.
 
@@ -62,7 +62,7 @@ Below the logos, you should see.
 
 ### Morpheus Version
 
-The Morpheus title and version in Yellow - it currently says "Morpheus Firmware: v 0.28.1"
+The Morpheus title and version in Yellow - it currently says "Morpheus Firmware: v1.0.0"
 
 ### Storage Type
 


### PR DESCRIPTION
I noticed Morpheus version referenced was out of date. ALso there was a firmware API function  that hadn't been pulled in from to firmware repo yet.