### PR TITLE
Feature: Add code examples to Clear Screen API documentation

### DIFF
--- a/neo6502/docs/reference/api-listing.md
+++ b/neo6502/docs/reference/api-listing.md
@@ -123,9 +123,9 @@ Clears the screen.
 
 <details>
 
-<summary>Assembler example</summary>
+<summary>Assembly example</summary>
 
-The following code is a stand alone example of clearing the screen:
+The following code is a stand alone example of clearing the screen in assembly:
 
 ```
 ; --- API Control Registers and Constants ---
@@ -160,6 +160,34 @@ API_GROUP_CONSOLE       = $02               ; ID for the 'Console' function grou
 ```
 
 </details>
+
+<details>
+
+<summary>C example</summary>
+
+The following code is a stand alone example of clearing the screen in C:
+
+```
+#include <stdio.h>
+
+#define CC_CLS 0x0C               /* ID for the 'Clear Screen' function (12 decimal, 0x0C hexadecimal) */
+
+int main(void) {
+
+    printf("Hello, this text will soon disappear!");
+
+    // Wait for a keypress
+    getchar();
+
+    // Clear the entire screen
+    putchar(CC_CLS);
+
+    printf("The screen has been cleared.");
+
+    return 0;
+}
+```
+
 
 ### Function 13 : Cursor Position
 

--- a/neo6502/docs/reference/api-listing.md
+++ b/neo6502/docs/reference/api-listing.md
@@ -121,6 +121,46 @@ This is a support function which deletes a line in the console and should not be
 
 Clears the screen.
 
+<details>
+
+<summary>Assembler example</summary>
+
+The following code is a stand alone example of clearing the screen:
+
+```
+; --- API Control Registers and Constants ---
+ControlPort             = $FF00             ; Base address for the system API control registers
+API_COMMAND             = ControlPort + 0   ; API Command/Status Register (write to execute, read for status)
+API_FUNCTION            = ControlPort + 1   ; API Function Selection Register
+
+API_FN_CLEAR_SCREEN     = $0C               ; ID for the 'Clear Screen' function (12 decimal, $0C hexadecimal)
+API_GROUP_CONSOLE       = $02               ; ID for the 'Console' function group (2 decimal, $02 hexadecimal)
+
+
+; --- API Call Logic ---
+
+        ; Step 1: Select the function to be executed.
+        ; We place the function ID into the API_FUNCTION slot to tell the API
+        ; what we want to do in the next step.
+        lda #API_FN_CLEAR_SCREEN
+        sta API_FUNCTION
+
+    @wait_api:
+        ; Step 2: Wait for the API to be ready.
+        ; This loop reads the status from API_COMMAND until it returns 0, ensuring
+        ; any previous operation is complete before we issue a new one.
+        lda API_COMMAND
+        bne @wait_api
+
+        ; Step 3: Execute the selected function.
+        ; Loading the 'Console' group ID and storing it in the API_COMMAND register
+        ; triggers the 'Clear Screen' function we selected in Step 1.
+        lda #API_GROUP_CONSOLE
+        sta API_COMMAND
+```
+
+</details>
+
 ### Function 13 : Cursor Position
 
 Returns the current screen character cell of the cursor in Parameter:0 (X), Parameter:1 (Y).

--- a/neo6502/docs/reference/api-listing.md
+++ b/neo6502/docs/reference/api-listing.md
@@ -176,10 +176,10 @@ int main(void) {
 
     printf("Hello, this text will soon disappear!");
 
-    // Wait for a keypress
+    /* Wait for a keypress */
     getchar();
 
-    // Clear the entire screen
+    /* Clear the entire screen */
     putchar(CC_CLS);
 
     printf("The screen has been cleared.");


### PR DESCRIPTION
**Description**:
This MR adds Assembly and C code examples to the documentation for API Function 12 (Clear Screen).

**Reasoning**:
The existing documentation describes the function's purpose but lacks a practical implementation guide. These examples provide developers with ready-to-use snippets that demonstrate the correct API protocol, which should help reduce ramp-up time.

Please review the changes and accept if you are happy.  If this MR gets accepted I'll raise more for other functions.